### PR TITLE
Amortize allocations in sarama.snappyDecode

### DIFF
--- a/snappy.go
+++ b/snappy.go
@@ -18,14 +18,16 @@ func snappyEncode(src []byte) ([]byte, error) {
 func snappyDecode(src []byte) ([]byte, error) {
 	if bytes.Equal(src[:8], snappyMagic) {
 		var (
-			pos = uint32(16)
-			max = uint32(len(src))
-			dst []byte
+			pos   = uint32(16)
+			max   = uint32(len(src))
+			dst   = make([]byte, 0, len(src))
+			chunk []byte
 		)
 		for pos < max {
 			size := binary.BigEndian.Uint32(src[pos : pos+4])
 			pos = pos + 4
-			chunk, err := snappy.Decode(nil, src[pos:pos+size])
+
+			chunk, err := snappy.Decode(chunk, src[pos:pos+size])
 			if err != nil {
 				return nil, err
 			}

--- a/snappy.go
+++ b/snappy.go
@@ -22,12 +22,13 @@ func snappyDecode(src []byte) ([]byte, error) {
 			max   = uint32(len(src))
 			dst   = make([]byte, 0, len(src))
 			chunk []byte
+			err   error
 		)
 		for pos < max {
 			size := binary.BigEndian.Uint32(src[pos : pos+4])
 			pos = pos + 4
 
-			chunk, err := snappy.Decode(chunk, src[pos:pos+size])
+			chunk, err = snappy.Decode(chunk, src[pos:pos+size])
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Heap profiling for the observation and metric consumers shows that we allocate a large portion of our working heap in Sarama's `snappyDecode` function. Amortize the allocations made when decoding a message set to reduce alloc/GC pressure in the consumers.