### PR TITLE
Randomly schedule metadata updates

### DIFF
--- a/client.go
+++ b/client.go
@@ -554,10 +554,18 @@ func (client *client) backgroundMetadataUpdater() {
 
 	ticker := time.NewTicker(client.conf.Metadata.RefreshFrequency)
 	defer ticker.Stop()
+	random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+	sleepThreshold := int64(client.conf.Metadata.RefreshFrequency) / 2
 
 	for {
 		select {
 		case <-ticker.C:
+			if client.conf.Metadata.RandomRefresh {
+				// Add a random sleep before refreshing metaData in the client.
+				// This will be bounded, up to client.conf.Metadata.RefreshFrequency/2.
+				time.Sleep(time.Duration(random.Int63n(sleepThreshold)))
+			}
+
 			if err := client.RefreshMetadata(); err != nil {
 				Logger.Println("Client background metadata update:", err)
 			}

--- a/client.go
+++ b/client.go
@@ -555,18 +555,15 @@ func (client *client) backgroundMetadataUpdater() {
 	ticker := time.NewTicker(client.conf.Metadata.RefreshFrequency)
 	defer ticker.Stop()
 	random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
-	if client.conf.Metadata.RandomRefreshBuffer > 0 {
-		sleepThreshold := int64(client.conf.Metadata.RefreshFrequency - client.conf.Metadata.RandomRefreshBuffer)
-	}
 
 	for {
 		select {
 		case <-ticker.C:
-			if client.conf.Metadata.RandomRefreshBuffer > 0 {
+			if client.conf.Metadata.RandomRefreshFrequency > 0 {
 				// Add a random sleep before refreshing metaData in the client.
 				// This will be bounded, up to
 				// client.conf.Metadata.RefreshFrequency - client.conf.Metadata.RandomRefreshBuffer.
-				time.Sleep(time.Duration(random.Int63n(sleepThreshold)))
+				time.Sleep(time.Duration(random.Int63n(int64(client.conf.Metadata.RandomRefreshFrequency))))
 			}
 
 			if err := client.RefreshMetadata(); err != nil {

--- a/client.go
+++ b/client.go
@@ -555,14 +555,17 @@ func (client *client) backgroundMetadataUpdater() {
 	ticker := time.NewTicker(client.conf.Metadata.RefreshFrequency)
 	defer ticker.Stop()
 	random := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
-	sleepThreshold := int64(client.conf.Metadata.RefreshFrequency) / 2
+	if client.conf.Metadata.RandomRefreshBuffer > 0 {
+		sleepThreshold := int64(client.conf.Metadata.RefreshFrequency - client.conf.Metadata.RandomRefreshBuffer)
+	}
 
 	for {
 		select {
 		case <-ticker.C:
-			if client.conf.Metadata.RandomRefresh {
+			if client.conf.Metadata.RandomRefreshBuffer > 0 {
 				// Add a random sleep before refreshing metaData in the client.
-				// This will be bounded, up to client.conf.Metadata.RefreshFrequency/2.
+				// This will be bounded, up to
+				// client.conf.Metadata.RefreshFrequency - client.conf.Metadata.RandomRefreshBuffer.
 				time.Sleep(time.Duration(random.Int63n(sleepThreshold)))
 			}
 

--- a/config.go
+++ b/config.go
@@ -52,6 +52,11 @@ type Config struct {
 		// Defaults to 10 minutes. Set to 0 to disable. Similar to
 		// `topic.metadata.refresh.interval.ms` in the JVM version.
 		RefreshFrequency time.Duration
+
+		// If enabled, cluster metadata refreshes will be scheduled randomly
+		// within the window specified by RefreshFrequency, to avoid concurrent
+		// updates by multiple clients started together.
+		RandomRefresh bool
 	}
 
 	// Producer is the namespace for configuration related to producing messages,

--- a/config.go
+++ b/config.go
@@ -53,10 +53,11 @@ type Config struct {
 		// `topic.metadata.refresh.interval.ms` in the JVM version.
 		RefreshFrequency time.Duration
 
-		// If set, Cluster metadata refreshes will be scheduled randomly
-		// within the window specified by (RefreshFrequency - RandomRefreshBuffer),
-		// to avoid concurrent updates by multiple clients started together.
-		RandomRefreshBuffer time.Duration
+		// If set, Cluster metadata refreshes will be scheduled randomly each
+		// RefreshFrequency tick for a time up to RandomRefreshFrequency in the
+		// future, to avoid concurrent updates by multiple clients started together.
+		// Defaults to 0 (off).
+		RandomRefreshFrequency time.Duration
 	}
 
 	// Producer is the namespace for configuration related to producing messages,
@@ -290,8 +291,8 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Metadata.Retry.Backoff must be >= 0")
 	case c.Metadata.RefreshFrequency < 0:
 		return ConfigurationError("Metadata.RefreshFrequency must be >= 0")
-	case c.Metadata.RandomRefreshBuffer > c.Metadata.RefreshFrequency:
-		return ConfigurationError("Metadata.RandomRefreshBuffer must be < Metadata.RefreshFrequency")
+	case c.Metadata.RandomRefreshFrequency > c.Metadata.RefreshFrequency:
+		return ConfigurationError("Metadata.RandomRefreshFrequency must be < Metadata.RefreshFrequency")
 	}
 
 	// validate the Producer values

--- a/config.go
+++ b/config.go
@@ -53,10 +53,10 @@ type Config struct {
 		// `topic.metadata.refresh.interval.ms` in the JVM version.
 		RefreshFrequency time.Duration
 
-		// If enabled, cluster metadata refreshes will be scheduled randomly
-		// within the window specified by RefreshFrequency, to avoid concurrent
-		// updates by multiple clients started together.
-		RandomRefresh bool
+		// If set, Cluster metadata refreshes will be scheduled randomly
+		// within the window specified by (RefreshFrequency - RandomRefreshBuffer),
+		// to avoid concurrent updates by multiple clients started together.
+		RandomRefreshBuffer time.Duration
 	}
 
 	// Producer is the namespace for configuration related to producing messages,
@@ -290,6 +290,8 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Metadata.Retry.Backoff must be >= 0")
 	case c.Metadata.RefreshFrequency < 0:
 		return ConfigurationError("Metadata.RefreshFrequency must be >= 0")
+	case c.Metadata.RandomRefreshBuffer > c.Metadata.RefreshFrequency:
+		return ConfigurationError("Metadata.RandomRefreshBuffer must be < Metadata.RefreshFrequency")
 	}
 
 	// validate the Producer values


### PR DESCRIPTION
The backgroundMetadataUpdater task uses a simple time.Ticker that
triggers a periodic metadata refresh for a kafka client (once every 10
minutes by default). The metadata refresh itself communicates with the
kafka cluster, and we’re unable to produce/consume messages for a short
time as a result. This is usually fine though since the refresh is
infrequent, and is not a major delay.

However, when running many instances of a consumer/producer (like we do
at VividCortex) across a datacenter, metadata refreshes can trigger
minor storms of traffic when synchronized across all of the kafka
clients simultaneously. This can be mitigated rather easily by
introducing some randomization into the metadata refresh task.

This change adds a random sleep, up to half of the
Metadata.RefreshFrequency before every metadata update. Doing so should
mitigate the possibility for storms as a result of synchronized
updates, as it is far more likely for only 1 or two clients to update
their metadata in a datacenter concurrently (as opposed to when the
task is done predictably across all clients that are simultaneously
deployed).

The randomization added here is disabled by default, and can be enabled
by setting the Client’s Config.Metadata.RandomRefresh flag.