### PR TITLE
Update to use the newly forked snappy repo

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,1 +1,1 @@
-github.com/VividCortex/snappy-go 95c8b3dbfdc1434d842197c26eac9df193c6d722
+github.com/VividCortex/snappy 88ec5b9f8866bc97b9d5a96714786ace0384a064

--- a/snappy.go
+++ b/snappy.go
@@ -1,7 +1,7 @@
 package sarama
 
 import (
-	"github.com/VividCortex/snappy-go/snappy"
+	"github.com/VividCortex/snappy"
 
 	"bytes"
 	"encoding/binary"


### PR DESCRIPTION
We’re going to abandon the snappy-go repo that was originally forked
from Google Code, and replace it with a new fork based on the
github.com/golang snappy repo.